### PR TITLE
make screencast downloader work

### DIFF
--- a/code_school_scraper.rb
+++ b/code_school_scraper.rb
@@ -101,7 +101,6 @@ class CodeSchoolDownloader
     html = @browser.html
     page = Nokogiri::HTML.parse(html)
     sub_dir_name =  dir_name + '/' + page.css('h1 span:last').text.gsub(/\//,'-')
-    #binding.pry
     create_dir sub_dir_name
     begin
       puts "Opening video..."


### PR DESCRIPTION
1.  add `download_sreencasts` method
   - category with "ruby", html-css", "ios" etc.
   - change css selector with right screencast selector
   - use browser.back instead of closing  
2. correct screencast_selector
